### PR TITLE
feat: Add error HIGH_CONGESTION

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -12,6 +12,7 @@ export enum ErrorCode {
   SALE_PRICE_TOO_LOW = 'sale_price_too_low',
   QUOTA_REACHED = 'quota_reached',
   CONTRACT_ACCOUNT = 'contract_account',
+  HIGH_CONGESTION = 'high_congestion',
   USER_DENIED = 'user_denied'
 }
 


### PR DESCRIPTION
This PR adds a new error: `HIGH_CONGESTION` to track when the current network gas price exceeds the max gas price allowed.