### PR TITLE
fix: EIP-7702 wallets not allowed for meta transactions

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -132,8 +132,15 @@ export function getCode(provider: Provider, account: string) {
   ])
 }
 
+// EIP-7702 delegation designator: EOAs that delegate code execution still have
+// a private key and can sign. Their bytecode is 0xef01 + 20-byte target address.
+const EIP_7702_DELEGATION_PREFIX = '0xef01'
+
 export async function isContract(provider: Provider, account: string) {
   const bytecode = await getCode(provider, account)
+  if (bytecode.toLowerCase().startsWith(EIP_7702_DELEGATION_PREFIX)) {
+    return false
+  }
   return !isZeroAddress(bytecode)
 }
 

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -98,6 +98,18 @@ describe('#Utils', () => {
       const result = await isContract(fakeProvider, '0xcafebabe')
       expect(result).toBe(true)
     })
+    it('should return false for an EIP-7702 delegated EOA', async () => {
+      const mockRequest = jest
+        .fn()
+        .mockResolvedValue(
+          '0xef0100000069d8726b7135bbb9cd4c9f8e66b381d00000'
+        )
+      const fakeProvider = {
+        request: mockRequest
+      }
+      const result = await isContract(fakeProvider, '0xcafebabe')
+      expect(result).toBe(false)
+    })
   })
 
   describe('hexZeroPad', () => {


### PR DESCRIPTION
Users with EIP-7702 delegated wallets are unable to send meta-transactions. `sendMetaTransaction` throws a `"Contract accounts are not supported"` error even though these wallets are standard EOAs with private keys that can sign.

### Why this happens

[EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) allows an EOA to delegate code execution to a smart contract while retaining its private key. When delegation is active, `eth_getCode` returns a delegation designator (`0xef01` + 20-byte target address) instead of the usual empty `0x`.

The `isContract` check in `sendMetaTransaction` uses `eth_getCode` to determine if the sender is a contract account. It treats any non-empty bytecode as a contract. This means EIP-7702 delegated EOAs — which are fully capable of signing — get rejected as if they were smart contract wallets.

For example, an affected wallet returns:
```
eth_getCode("0xaae5...E3AC") → "0xef0100000069d8726b7135bbb9cd4c9f8e66b381d00000"
```

This is not contract bytecode — it's a 23-byte delegation designator. But because it's non-empty, `isContract` returns `true` and the meta-transaction is blocked.

### Fix

`isContract` now checks whether the bytecode starts with the `0xef01` prefix before classifying the account. If it does, the account is treated as an EOA (returns `false`), allowing the meta-transaction signing flow to proceed normally.

```ts
const EIP_7702_DELEGATION_PREFIX = '0xef01'

export async function isContract(provider: Provider, account: string) {
  const bytecode = await getCode(provider, account)
  if (bytecode.toLowerCase().startsWith(EIP_7702_DELEGATION_PREFIX)) {
    return false
  }
  return !isZeroAddress(bytecode)
}
```

